### PR TITLE
Add comments include to post layout

### DIFF
--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -26,4 +26,5 @@ layout: default
   <div class="post-content">
     {{ content }}
   </div>
+  {% include comments.html %}
 </article>


### PR DESCRIPTION
The comments partial was never included in the post layout template, so comments were not showing on any article pages.

https://claude.ai/code/session_01LNfqHqxy4xWJvFjVD2QzH2