### PR TITLE
Make chronology year summaries sticky with proper z-index

### DIFF
--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -592,6 +592,14 @@ img { max-width: 100%; }
   transition: background-color 0.2s;
   color: #1a1a1a;
   border-bottom: 2px solid transparent;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: var(--color-paper);
+}
+/* When inside home page tabs, offset for the sticky tab bar */
+.tabcontent .chronology-year-summary {
+  top: 42px;
 }
 details.chronology-year-section[open] > .chronology-year-summary {
   border-bottom-color: #3b82f6;

--- a/docs/chronology.html
+++ b/docs/chronology.html
@@ -77,6 +77,10 @@ title: 年谱
   transition: background-color 0.2s;
   color: #1a1a1a;
   border-bottom: 2px solid transparent;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: var(--color-paper, #f9f9f9);
 }
 details.chronology-year-section[open] > .chronology-year-summary {
   border-bottom-color: #3b82f6;


### PR DESCRIPTION
## Summary
This PR makes the chronology year summary headers sticky so they remain visible when scrolling through the timeline, improving navigation and context awareness.

## Key Changes
- Added `position: sticky`, `top: 0`, and `z-index: 10` to `.chronology-year-summary` to keep year headers fixed at the top while scrolling
- Set `background-color: var(--color-paper)` to prevent content from showing through the sticky header
- Added offset rule for `.tabcontent .chronology-year-summary` with `top: 42px` to account for tab bar height on the home page
- Applied changes to both the main CSS file (`custom.css`) and the inline styles in `chronology.html`

## Implementation Details
The sticky positioning uses a z-index of 10 to ensure the year headers stay above other content. The offset for tabbed content prevents the sticky header from overlapping with the tab navigation bar. The background color is explicitly set to match the page background, ensuring the header doesn't appear transparent when scrolling.

https://claude.ai/code/session_01CFHgXHfynykaduDQPPf2Js