### PR TITLE
Refactor chronology filtering with year-based display toggle

### DIFF
--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -247,8 +247,12 @@ title: 主页
 
   <div id="chronology" class="tabcontent">
     {%- comment -%}Build decade navigation from YAML data{%- endcomment -%}
-    <div class="chronology-year-nav is-collapsed" id="chronology-year-nav">
+    <div class="chronology-year-nav is-collapsed" id="chronology-year-nav-home">
     <button class="chronology-year-nav-toggle" onclick="this.parentElement.classList.toggle('is-collapsed')">年份导航</button>
+    <div class="chronology-year-nav-row">
+      <span class="chronology-decade-label">全部</span>
+      <a class="chronology-year-link" onclick="filterByYear('all', this, 'home')">显示全部</a>
+    </div>
     {%- assign prev_decade = "" -%}
     {%- for year_data in site.data.chronology -%}
       {%- assign decade = year_data.year | divided_by: 10 | times: 10 -%}
@@ -259,13 +263,13 @@ title: 主页
         <span class="chronology-decade-label">{{ decade_label }}</span>
         {%- assign prev_decade = decade_label -%}
       {%- endif -%}
-        <a class="chronology-year-link" onclick="jumpToYear('year-{{ year_data.year }}')">{{ year_data.year }}</a>
+        <a class="chronology-year-link" data-year="{{ year_data.year }}" onclick="filterByYear('{{ year_data.year }}', this, 'home')">{{ year_data.year }}</a>
     {%- endfor -%}
       </div>
     </div>
 
     {%- for year_data in site.data.chronology -%}
-    <details class="chronology-year-section" id="year-{{ year_data.year }}">
+    <details class="chronology-year-section" id="year-{{ year_data.year }}" data-year="{{ year_data.year }}" style="display:none;">
       <summary class="chronology-year-summary">【{{ year_data.year }}】</summary>
       <div class="chronology-entries">
         {%- for entry in year_data.entries -%}
@@ -380,31 +384,56 @@ title: 主页
     detailsElements.forEach((detail) => { detail.open = hasAClosedElement; });
   };
 
-  function toggleAllChronology() {
-    var sections = document.querySelectorAll('.chronology-year-section');
-    if (sections.length === 0) return;
-    var hasAClosedElement = Array.from(sections).some(function(s) { return !s.open; });
-    sections.forEach(function(s) { s.open = hasAClosedElement; });
-  }
+  function filterByYear(year, clickedLink, context) {
+    var navId = context === 'home' ? 'chronology-year-nav-home' : 'chronology-year-nav';
+    var navEl = document.getElementById(navId);
+    var container = navEl ? navEl.parentElement : document;
+    var sections = container.querySelectorAll('.chronology-year-section');
+    var links = navEl ? navEl.querySelectorAll('.chronology-year-link') : [];
 
-  function jumpToYear(yearId) {
-    var el = document.getElementById(yearId);
-    if (!el) return;
-    // On mobile, collapse the nav after selecting a year
-    if (window.innerWidth <= 600) {
-      var nav = document.getElementById('chronology-year-nav');
-      if (nav) nav.classList.add('is-collapsed');
+    // Update active tag
+    links.forEach(function(l) { l.classList.remove('active'); });
+    if (clickedLink) clickedLink.classList.add('active');
+
+    if (year === 'all') {
+      sections.forEach(function(s) {
+        s.style.display = '';
+        s.open = true;
+      });
+    } else {
+      sections.forEach(function(s) {
+        if (s.getAttribute('data-year') === year) {
+          s.style.display = '';
+          s.open = true;
+        } else {
+          s.style.display = 'none';
+        }
+      });
     }
-    el.open = true;
-    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    el.classList.add('highlight');
-    setTimeout(function() { el.classList.remove('highlight'); }, 1500);
+
+    // On mobile, collapse the nav after selecting
+    if (window.innerWidth <= 600 && navEl) {
+      navEl.classList.add('is-collapsed');
+    }
+
+    // Scroll to top of nav
+    if (navEl) navEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
 
   function toggleAllSmart() {
     var chronologyTab = document.getElementById('chronology');
     if (chronologyTab && chronologyTab.style.display !== 'none') {
-      toggleAllChronology();
+      // For chronology, toggle between showing all and showing first year
+      var allLink = document.querySelector('#chronology-year-nav-home .chronology-year-link:not([data-year])');
+      var activeLink = document.querySelector('#chronology-year-nav-home .chronology-year-link.active');
+      if (activeLink && !activeLink.getAttribute('data-year')) {
+        // Currently showing all, switch to first year
+        var firstLink = document.querySelector('#chronology-year-nav-home .chronology-year-link[data-year]');
+        if (firstLink) filterByYear(firstLink.getAttribute('data-year'), firstLink, 'home');
+      } else {
+        // Currently showing a single year, show all
+        if (allLink) filterByYear('all', allLink, 'home');
+      }
     } else {
       toggleAllMaster('#new-view .collapsible-book');
     }
@@ -441,6 +470,10 @@ title: 主页
 
     openTabFromHash();
     window.addEventListener('hashchange', openTabFromHash, false);
+
+    // Initialize chronology: select the first year by default
+    var firstChronoLink = document.querySelector('#chronology-year-nav-home .chronology-year-link[data-year]');
+    if (firstChronoLink) filterByYear(firstChronoLink.getAttribute('data-year'), firstChronoLink, 'home');
 
     // 点击外部关闭订阅下拉框
     document.addEventListener('click', function(e) {

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -603,10 +603,19 @@ img { max-width: 100%; }
   padding: 2px 6px;
   border-radius: 3px;
   cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
 }
 .chronology-year-link:hover {
   background-color: #e8f0fe;
   text-decoration: none;
+}
+.chronology-year-link.active {
+  background-color: #2563eb;
+  color: #fff;
+  font-weight: 600;
+}
+.chronology-year-link.active:hover {
+  background-color: #1d4ed8;
 }
 .chronology-year-section {
   border-bottom: 1px solid #e5e7eb;

--- a/docs/chronology.html
+++ b/docs/chronology.html
@@ -73,10 +73,19 @@ title: 年谱
   padding: 2px 6px;
   border-radius: 3px;
   cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
 }
 .chronology-year-link:hover {
   background-color: #e8f0fe;
   text-decoration: none;
+}
+.chronology-year-link.active {
+  background-color: #2563eb;
+  color: #fff;
+  font-weight: 600;
+}
+.chronology-year-link.active:hover {
+  background-color: #1d4ed8;
 }
 
 /* ===== Year Sections ===== */
@@ -313,6 +322,10 @@ details.chronology-year-section:not([open]) > .chronology-year-summary::before {
 {% comment %}Build decade navigation from YAML data{% endcomment %}
 <div class="chronology-year-nav is-collapsed" id="chronology-year-nav">
 <button class="chronology-year-nav-toggle" onclick="this.parentElement.classList.toggle('is-collapsed')">年份导航</button>
+<div class="chronology-year-nav-row">
+  <span class="chronology-decade-label">全部</span>
+  <a class="chronology-year-link" onclick="filterByYear('all', this)">显示全部</a>
+</div>
 {% assign prev_decade = "" %}
 {% for year_data in site.data.chronology %}
   {% assign decade = year_data.year | divided_by: 10 | times: 10 %}
@@ -323,17 +336,13 @@ details.chronology-year-section:not([open]) > .chronology-year-summary::before {
     <span class="chronology-decade-label">{{ decade_label }}</span>
     {% assign prev_decade = decade_label %}
   {% endif %}
-    <a class="chronology-year-link" onclick="jumpToYear('year-{{ year_data.year }}')">{{ year_data.year }}</a>
+    <a class="chronology-year-link" data-year="{{ year_data.year }}" onclick="filterByYear('{{ year_data.year }}', this)">{{ year_data.year }}</a>
 {% endfor %}
   </div>
 </div>
 
-<div class="chronology-toggle-wrapper">
-  <button class="chronology-toggle-btn" onclick="toggleAllChronology()">全部展开/收起</button>
-</div>
-
 {% for year_data in site.data.chronology %}
-<details class="chronology-year-section" id="year-{{ year_data.year }}">
+<details class="chronology-year-section" id="year-{{ year_data.year }}" data-year="{{ year_data.year }}" style="display:none;">
   <summary class="chronology-year-summary">【{{ year_data.year }}】</summary>
   <div class="chronology-entries">
     {% for entry in year_data.entries %}
@@ -359,24 +368,44 @@ details.chronology-year-section:not([open]) > .chronology-year-summary::before {
 {% endfor %}
 
 <script>
-function toggleAllChronology() {
+function filterByYear(year, clickedLink) {
   var sections = document.querySelectorAll('.chronology-year-section');
-  if (sections.length === 0) return;
-  var hasAClosedElement = Array.from(sections).some(function(s) { return !s.open; });
-  sections.forEach(function(s) { s.open = hasAClosedElement; });
-}
+  var links = document.querySelectorAll('#chronology-year-nav .chronology-year-link');
 
-function jumpToYear(yearId) {
-  var el = document.getElementById(yearId);
-  if (!el) return;
-  // On mobile, collapse the nav after selecting a year
+  // Update active tag
+  links.forEach(function(l) { l.classList.remove('active'); });
+  if (clickedLink) clickedLink.classList.add('active');
+
+  if (year === 'all') {
+    sections.forEach(function(s) {
+      s.style.display = '';
+      s.open = true;
+    });
+  } else {
+    sections.forEach(function(s) {
+      if (s.getAttribute('data-year') === year) {
+        s.style.display = '';
+        s.open = true;
+      } else {
+        s.style.display = 'none';
+      }
+    });
+  }
+
+  // On mobile, collapse the nav after selecting
   if (window.innerWidth <= 600) {
     var nav = document.getElementById('chronology-year-nav');
     if (nav) nav.classList.add('is-collapsed');
   }
-  el.open = true;
-  el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  el.classList.add('highlight');
-  setTimeout(function() { el.classList.remove('highlight'); }, 1500);
+
+  // Scroll to top of content area
+  var nav = document.getElementById('chronology-year-nav');
+  if (nav) nav.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
+
+// Select the first year by default on page load
+document.addEventListener('DOMContentLoaded', function() {
+  var firstLink = document.querySelector('#chronology-year-nav .chronology-year-link[data-year]');
+  if (firstLink) filterByYear(firstLink.getAttribute('data-year'), firstLink);
+});
 </script>


### PR DESCRIPTION
## Summary
Replaced the chronology "expand/collapse all" functionality with a year-based filtering system that allows users to view all entries or filter by a specific year. The navigation now includes an active state indicator and defaults to showing the first year on page load.

## Key Changes
- **Replaced toggle functionality**: Removed `toggleAllChronology()` and `jumpToYear()` functions in favor of a new `filterByYear()` function that filters sections by year
- **Added "Show All" option**: Introduced a "全部" (All) link at the top of the year navigation to display all chronology entries
- **Year-based filtering**: Sections now have `data-year` attributes and are hidden/shown based on the selected year filter
- **Active state styling**: Added `.chronology-year-link.active` class with blue background (#2563eb) to indicate the currently selected year
- **Default selection**: Page now automatically selects and displays the first year on load via `DOMContentLoaded` event
- **Mobile UX**: Navigation collapses after year selection on mobile devices (≤600px width)
- **Smooth transitions**: Added CSS transitions (0.15s) for background-color and color changes on year links
- **Context-aware filtering**: Home page version uses `chronology-year-nav-home` ID to support multiple chronology sections with independent filtering

## Implementation Details
- All chronology year sections are initially hidden (`style="display:none;"`) and shown only when their year is selected
- The `filterByYear()` function accepts a `context` parameter ('home' or default) to support multiple chronology instances
- Removed the separate "全部展开/收起" (Expand/Collapse All) button from the chronology.html page
- Updated both home.html and chronology.html with consistent filtering logic
- CSS styling updated in both chronology.html and custom.css for consistency

https://claude.ai/code/session_01ANteMLj32BeYQ7UDtXDVC3