### PR TITLE
Add encoding: utf-8 to _config.yml for Cloudflare Pages build

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -29,6 +29,7 @@ url: "https://lyxmemo.github.io" # the base hostname & protocol for your site, e
 github_username:  lyxmemo
 locale: zh_CN
 lang: zh-CN
+encoding: utf-8
 
 # Social media links - update or remove as needed
 social:


### PR DESCRIPTION
Ruby 3.4's stricter encoding handling causes "incompatible character encodings: UTF-8 and BINARY" errors when building with Chinese content. Explicitly set encoding to utf-8 in Jekyll config.

https://claude.ai/code/session_01BxRUFqA6DdqGakexXUxXzu