### PR TITLE
Fix UTF-8 encoding issues in Jekyll document rendering

### DIFF
--- a/docs/_plugins/force_utf8.rb
+++ b/docs/_plugins/force_utf8.rb
@@ -1,0 +1,9 @@
+# Force UTF-8 encoding on all document content to prevent
+# "incompatible character encodings: UTF-8 and ASCII-8BIT" errors
+# when building on platforms where the default encoding is not UTF-8.
+
+Jekyll::Hooks.register [:documents, :pages], :pre_render do |doc|
+  if doc.content.encoding != Encoding::UTF_8
+    doc.content = doc.content.force_encoding('UTF-8')
+  end
+end


### PR DESCRIPTION
## Summary
Add a Jekyll plugin to force UTF-8 encoding on all document and page content during the pre-render phase. This prevents "incompatible character encodings: UTF-8 and ASCII-8BIT" errors when building documentation on platforms where the default encoding is not UTF-8.

## Changes
- Added `docs/_plugins/force_utf8.rb` - A new Jekyll hook plugin that:
  - Registers a pre-render hook for both documents and pages
  - Checks if document content encoding is not UTF-8
  - Forces UTF-8 encoding on content that uses a different encoding
  - Prevents encoding mismatch errors during the build process

## Implementation Details
The plugin uses Jekyll's hook system to intercept documents and pages before rendering. By checking and converting the encoding at this early stage, it ensures consistent UTF-8 handling across all platforms regardless of the system's default encoding settings.

https://claude.ai/code/session_01Vi25NkMQw5oSxAyTcQzjhE