### PR TITLE
Fix BreadcrumbList structured data: add missing item URLs

### DIFF
--- a/docs/_layouts/category.html
+++ b/docs/_layouts/category.html
@@ -8,7 +8,7 @@ layout: default
   </span>
   <span aria-hidden="true"> / </span>
   <span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-    <span itemprop="name">{{ page.title }}</span>
+    <a itemprop="item" href="{{ page.url | absolute_url }}"><span itemprop="name">{{ page.title }}</span></a>
     <meta itemprop="position" content="2">
   </span>
 </nav>

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -35,12 +35,12 @@ layout: default
       </li>
       {%- if page.category -%}
       <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-        <span itemprop="name">{{ page.category }}</span>
+        <a itemprop="item" href="{{ site.baseurl }}/categories/{{ page.category | slugify }}/"><span itemprop="name">{{ page.category }}</span></a>
         <meta itemprop="position" content="2">
       </li>
       {%- endif -%}
       <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-        <span itemprop="name">{{ page.title }}</span>
+        <a itemprop="item" href="{{ page.url | absolute_url }}"><span itemprop="name">{{ page.title }}</span></a>
         <meta itemprop="position" content="3">
       </li>
     </ol>


### PR DESCRIPTION
Every BreadcrumbList ListItem requires an "item" property with a URL. The category and current-page breadcrumbs were missing this, causing Google Search Console to report critical structured data errors on all ~738 collection pages.

https://claude.ai/code/session_01BxRUFqA6DdqGakexXUxXzu