### PR TITLE
Fix Waline comments path configuration

### DIFF
--- a/docs/_includes/comments.html
+++ b/docs/_includes/comments.html
@@ -12,6 +12,7 @@
     init({
       el: '#waline',
       serverURL: '{{ site.comments.waline.server_url }}',
+      path: decodeURI(window.location.pathname),
       lang: '{{ site.comments.waline.lang | default: "zh-CN" }}',
       placeholder: '{{ site.comments.waline.placeholder | default: "欢迎留言" }}',
       pageSize: {{ site.comments.waline.page_size | default: 10 }},


### PR DESCRIPTION
## Summary
This change fixes the Waline comment system initialization by explicitly setting the `path` parameter to use the current page's URI-decoded pathname.

## Changes
- Added `path: decodeURI(window.location.pathname)` to the Waline initialization configuration
  - This ensures each page has its own separate comment thread based on its URL path
  - The `decodeURI()` function properly handles encoded characters in URLs

## Details
Previously, the Waline comment configuration did not explicitly specify a path, which could cause comments from different pages to be mixed together or not properly associated with their respective pages. By setting the path to the current page's pathname (decoded to handle special characters), each page now maintains its own independent comment thread.

https://claude.ai/code/session_01Q6sD3EggHCu41a3xKStTNd