### PR TITLE
Refine handwritten manuscript transcriptions with contributor corrections

### DIFF
--- a/docs/_newspapers/19681125廖耀湘谈话记录.md
+++ b/docs/_newspapers/19681125廖耀湘谈话记录.md
@@ -8,7 +8,7 @@ date: 1968-11-25 00:00:00 +0000
 ---
 
 <p class="manuscript-note">
-  本页将手写原件与文字转录并排展示，以便读者对照阅读。文字中<span class="unclear">[?]</span>标记表示字迹难以辨认之处，欢迎读者协助校正。
+  本页将手写原件与文字转录并排展示，以便读者对照阅读。文字中<span class="unclear">[?]</span>标记表示字迹难以辨认之处，欢迎读者协助校正。感谢【沈郎瘦尽】的补充订正。
 </p>
 
 <!-- 第一页 -->
@@ -23,17 +23,17 @@ date: 1968-11-25 00:00:00 +0000
       <div class="ms-line ms-line--title" data-img-y="11">&emsp;&emsp;廖耀湘谈话记录</div>
       <div class="ms-line" data-img-y="17">&emsp;&emsp;第九兵团是1947年1月成立的，由新三、新</div>
       <div class="ms-line" data-img-y="22">六军组成。</div>
-      <div class="ms-line" data-img-y="27">&emsp;&emsp;包括连指导员、团指导员、团<span class="unclear">[?][?]</span>、师里的</div>
+      <div class="ms-line" data-img-y="27">&emsp;&emsp;包括连指导员、团指导员、团<span class="unclear">[干][事]</span>、师里的</div>
       <div class="ms-line" data-img-y="32">政工人员、政工队员。</div>
       <div class="ms-line" data-img-y="37">&emsp;&emsp;时间两三礼拜。</div>
-      <div class="ms-line" data-img-y="42">&emsp;&emsp;主任<span class="unclear">[?][?][?]</span>组成，实际上是蔡仙</div>
-      <div class="ms-line" data-img-y="47"><span class="unclear">[?]</span>主任</div>
-      <div class="ms-line" data-img-y="52">&emsp;&emsp;训练的主要内容：是让下面人都彼此</div>
-      <div class="ms-line" data-img-y="57">认识一下（蔡<span class="unclear">[?][?]</span>到差）&emsp;&emsp;&emsp;&emsp;关于工作任务</div>
+      <div class="ms-line" data-img-y="42">&emsp;&emsp;主任<span class="unclear">[明][义][上][是][我]</span>，实际上是蔡仙<span class="unclear">[俊]</span></div>
+      <div class="ms-line" data-img-y="47">主任</div>
+      <div class="ms-line" data-img-y="52">&emsp;&emsp;训练的主要内容：是让下<span class="unclear">[属][的]</span>人都彼此</div>
+      <div class="ms-line" data-img-y="57">认识一下（蔡<span class="unclear">[是][新]</span>到差）&emsp;&emsp;&emsp;&emsp;关于工作<span class="unclear">[业]</span>务</div>
       <div class="ms-line" data-img-y="62">统一规定一下。</div>
       <div class="ms-line" data-img-y="67">&emsp;&emsp;也讲国民党当时的形势教育，我也讲</div>
       <div class="ms-line" data-img-y="72">过两次话。</div>
-      <div class="ms-line" data-img-y="77">&emsp;&emsp;1947年底或1948年初，是<span class="unclear">[?]</span>委我</div>
+      <div class="ms-line" data-img-y="77">&emsp;&emsp;1947年底或1948年初，是<span class="unclear">[冬][季?]</span>我</div>
       <div class="ms-line" data-img-y="83">去讲过话。</div>
       <div class="ms-line" data-img-y="89">&emsp;&emsp;地址在沈阳一个警察局里面。</div>
     </div>
@@ -57,20 +57,20 @@ date: 1968-11-25 00:00:00 +0000
     <div class="manuscript-text">
       <div class="ms-line" data-img-y="8">&emsp;&emsp;军里两个主任新六军<span class="unclear">[?]</span>志坚，新三军梁直兵</div>
       <div class="ms-line" data-img-y="13">担任训练，师里的政治部主任都来了。</div>
-      <div class="ms-line" data-img-y="19">&emsp;&emsp;共训练两期，最<span class="unclear">[?]</span>是三期。</div>
+      <div class="ms-line" data-img-y="19">&emsp;&emsp;共训练两期，最<span class="unclear">[多]</span>是三期。</div>
       <div class="ms-line" data-img-y="24">&emsp;&emsp;性质：国民党部队的政治训练机构。</div>
       <div class="ms-line" data-img-y="29">在职人员。</div>
       <div class="ms-line" data-img-y="34">&emsp;&emsp;连里的有少尉中尉，有少将上将</div>
-      <div class="ms-line" data-img-y="39">付师长<span class="unclear">[?]</span>政治部。</div>
+      <div class="ms-line" data-img-y="39">付师长政治部。</div>
       <div class="ms-line" data-img-y="44">&emsp;&emsp;每师每军都有政工人员、政工队员</div>
-      <div class="ms-line" data-img-y="49">有准尉少尉。 <span class="unclear">[?][?][?]</span>，<span class="unclear">[?][?][?]</span>教育</div>
+      <div class="ms-line" data-img-y="49">有准尉少尉。 <span class="unclear">[办][宣][传]</span>，<span class="unclear">[搞][精][神]</span>教育</div>
       <div class="ms-line" data-img-y="54">政工人员。</div>
-      <div class="ms-line" data-img-y="59">&emsp;&emsp;受训人员都是党员，都是参加国民党为</div>
+      <div class="ms-line" data-img-y="59">&emsp;&emsp;受训人员都是<span class="unclear">[官][长]</span>，都是参加国民党为</div>
       <div class="ms-line" data-img-y="64">党员的，就是不是党员的，也当党员对待。</div>
-      <div class="ms-line" data-img-y="69">军官收党费，有些军官就没有新入党</div>
-      <div class="ms-line" data-img-y="74"><span class="unclear">[?][?]</span>，但他过组织生活，被称为党员</div>
+      <div class="ms-line" data-img-y="69">军官收党费，有些军官就没有<span class="unclear">[履][行]</span>入党</div>
+      <div class="ms-line" data-img-y="74"><span class="unclear">[手][续]</span>，但他过组织生活，被称为党员</div>
       <div class="ms-line" data-img-y="79">的党员。</div>
-      <div class="ms-line" data-img-y="86">&emsp;&emsp;政工队员有的人入党有人没有入党</div>
+      <div class="ms-line" data-img-y="86">&emsp;&emsp;政工队员有的人入党有<span class="unclear">[的]</span>没有入党</div>
     </div>
     <div class="manuscript-notes">
       <div class="ms-note" style="top: 8%">「梁直兵」应为梁直平<sup>③</sup></div>
@@ -100,11 +100,11 @@ date: 1968-11-25 00:00:00 +0000
       <div class="ms-line" data-img-y="48">国的军队一起打回缅甸。</div>
       <div class="ms-line" data-img-y="53"></div>
       <div class="ms-line" data-img-y="60">&emsp;&emsp;1944年10月新六军从缅甸回国，由美国</div>
-      <div class="ms-line" data-img-y="65">人用飞机运会与南</div>
-      <div class="ms-line" data-img-y="70">&emsp;&emsp;1945年3月日本人及<span class="unclear">[?][?][?]</span>美国援助国民</div>
+      <div class="ms-line" data-img-y="65">人用飞机运会<span class="unclear">[云]</span>南</div>
+      <div class="ms-line" data-img-y="70">&emsp;&emsp;1945年3月日本人<span class="unclear">[要][摧][毁]</span>美国援助国民</div>
       <div class="ms-line" data-img-y="75">党的基地。美国又用飞机从</div>
       <div class="ms-line" data-img-y="80">云南把新六军运到湖南。这次</div>
-      <div class="ms-line" data-img-y="86">战役<span class="unclear">[?]</span>雪峰山战役</div>
+      <div class="ms-line" data-img-y="86">战役<span class="unclear">[叫]</span>雪峰山战役</div>
     </div>
     <div class="manuscript-notes">
       <div class="ms-note" style="top: 28%">「又去了一个军」不确<sup>⑤</sup></div>
@@ -132,14 +132,14 @@ date: 1968-11-25 00:00:00 +0000
       <div class="ms-line" data-img-y="28">那时41、42军已进入东北。</div>
       <div class="ms-line" data-img-y="33">&emsp;&emsp;46年2月初在锦州以东地区</div>
       <div class="ms-line" data-img-y="38">&emsp;&emsp;解放前夕</div>
-      <div class="ms-line" data-img-y="43">&emsp;&emsp;<span class="unclear">[?]</span>西兵团，有新一军、新六军。</div>
+      <div class="ms-line" data-img-y="43">&emsp;&emsp;<span class="unclear">[廖]</span>两兵团，有新一军、新六军。</div>
       <div class="ms-line" data-img-y="48">&emsp;&emsp;48年辽沈战役主要歼灭第九兵</div>
       <div class="ms-line" data-img-y="53">团。</div>
-      <div class="ms-line" data-img-y="58">&emsp;&emsp;新六军<span class="unclear">[?]</span>第九兵团<span class="unclear">[?]</span>。</div>
+      <div class="ms-line" data-img-y="58">&emsp;&emsp;新六军<span class="unclear">[属]</span>第九兵团<span class="unclear">[管]</span>。</div>
       <div class="ms-line" data-img-y="63"></div>
       <div class="ms-line" data-img-y="68">&emsp;&emsp;政工队员情况：</div>
       <div class="ms-line" data-img-y="74">&emsp;&emsp;主要是文娱活动，京剧团很早就有了</div>
-      <div class="ms-line" data-img-y="80">话剧团在东北招收，<span class="unclear">[?][?][?]</span>，还</div>
+      <div class="ms-line" data-img-y="80">话剧团在东北招<span class="unclear">[攷]</span>，<span class="unclear">[电][影][队]</span>，还</div>
       <div class="ms-line" data-img-y="86">有小报刊。帮助军队办军民合作</div>
     </div>
     <div class="manuscript-notes">
@@ -162,20 +162,20 @@ date: 1968-11-25 00:00:00 +0000
       <img src="/assets/images/1968-11-25-liaoyaoxiang-tanhua/5.png" alt="第五页手迹">
     </div>
     <div class="manuscript-text">
-      <div class="ms-line" data-img-y="8">社，有团政治部主任<span class="unclear">[?][?][?]</span>，<span class="unclear">[?][?]</span>既</div>
-      <div class="ms-line" data-img-y="13">是政工人员。</div>
-      <div class="ms-line" data-img-y="18">&emsp;&emsp;军民合作社，主要是买粮食，<span class="unclear">[?]</span></div>
-      <div class="ms-line" data-img-y="23"><span class="unclear">[?]</span>保长联系。防止军队败坏纪律</div>
-      <div class="ms-line" data-img-y="28"><span class="unclear">[?][?]</span>，和当地搞好军民关系，帮助</div>
+      <div class="ms-line" data-img-y="8">社，有团政治部主任<span class="unclear">[直][接][管]</span>，<span class="unclear">[下][面][跑]</span></div>
+      <div class="ms-line" data-img-y="13"><span class="unclear">[腿]</span>是政工人员。</div>
+      <div class="ms-line" data-img-y="18">&emsp;&emsp;军民合作社，主要是买粮食，<span class="unclear">[和]</span></div>
+      <div class="ms-line" data-img-y="23"><span class="unclear">[乡]</span>保长联系。防止军队败坏纪律</div>
+      <div class="ms-line" data-img-y="28"><span class="unclear">[的][事]</span>，和当地搞好军民关系，帮助</div>
       <div class="ms-line" data-img-y="33">地方政府开展工作。没有组织</div>
       <div class="ms-line" data-img-y="38">训练地方的任务。 也没有帮助</div>
       <div class="ms-line" data-img-y="43">地方的肃伪工作，如果地方要求，他</div>
-      <div class="ms-line" data-img-y="48">有的帮助。</div>
+      <div class="ms-line" data-img-y="48"><span class="unclear">[可][以]</span>帮助。</div>
       <div class="ms-line" data-img-y="53"></div>
       <div class="ms-line" data-img-y="58">&emsp;&emsp;政工队员也要上前线</div>
       <div class="ms-line" data-img-y="63">军师政工人员受军师指挥</div>
-      <div class="ms-line" data-img-y="68">&emsp;&emsp;军的政工队也有的到师里连里去帮</div>
-      <div class="ms-line" data-img-y="73">助工作，也有的调至当付官，<span class="unclear">[?]</span></div>
+      <div class="ms-line" data-img-y="68">&emsp;&emsp;军的政工队也<span class="unclear">[可][以]</span>到师里连里去帮</div>
+      <div class="ms-line" data-img-y="73">助工作，也<span class="unclear">[可][以]</span>调至当付官，<span class="unclear">[?]</span></div>
       <div class="ms-line" data-img-y="80">&emsp;&emsp;个人档案在国民党军队内根本</div>
       <div class="ms-line" data-img-y="86">没有</div>
     </div>


### PR DESCRIPTION
## Summary
This PR updates the transcription of the November 25, 1968 Liao Yaoxiang interview manuscript with refined character recognition and corrections contributed by community member 【沈郎瘦尽】.

## Key Changes
- Added acknowledgment to contributor 【沈郎瘦尽】 in the manuscript note header
- Refined unclear character markings throughout the document with more accurate transcriptions:
  - Replaced generic `[?][?]` placeholders with specific character pairs (e.g., `[干][事]`, `[属][的]`, `[多]`)
  - Corrected multi-character sequences with improved readings (e.g., `[明][义][上][是][我]` for a 5-character phrase)
  - Fixed individual character recognitions (e.g., `[云]` for "云", `[叫]` for "叫")
- Removed unnecessary unclear markers where text was clarified (e.g., "付师长政治部" instead of "付师长[?]政治部")
- Updated several lines with better contextual readings based on handwriting analysis

## Notable Details
- Changes span all five pages of the manuscript
- Improvements focus on political and military terminology relevant to the historical content
- All modifications maintain the original manuscript structure and image reference points (data-img-y attributes)

https://claude.ai/code/session_01Xw5FY9y6NHUz4ZLDkZ1vyY