### PR TITLE
文章页编辑杂志风格重设计

### DIFF
--- a/docs/_includes/comments.html
+++ b/docs/_includes/comments.html
@@ -18,7 +18,7 @@
       avatar: '{{ site.comments.waline.avatar | default: "mp" }}',
       meta: ['nick', 'mail'],
       requiredMeta: [],
-      pageview: true,
+      pageview: false,
       comment: true,
     });
   </script>

--- a/docs/_includes/reading-progress.html
+++ b/docs/_includes/reading-progress.html
@@ -1,0 +1,20 @@
+<div class="reading-progress" aria-hidden="true">
+  <div class="reading-progress-bar" id="reading-progress-bar"></div>
+</div>
+<script>
+(function() {
+  var bar = document.getElementById('reading-progress-bar');
+  var article = document.querySelector('.post-article, .manuscript-article');
+  if (!bar || !article) return;
+  function update() {
+    var rect = article.getBoundingClientRect();
+    var viewport = window.innerHeight;
+    var scrolled = Math.max(0, -rect.top);
+    var total = Math.max(1, rect.height - viewport);
+    bar.style.width = Math.min(100, Math.max(0, (scrolled / total) * 100)) + '%';
+  }
+  window.addEventListener('scroll', update, { passive: true });
+  window.addEventListener('resize', update);
+  update();
+})();
+</script>

--- a/docs/_layouts/manuscript.html
+++ b/docs/_layouts/manuscript.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+{% include reading-progress.html %}
 <article class="manuscript-article" itemscope itemtype="https://schema.org/Article">
   <div class="post-meta-bar">
     {%- case page.category -%}

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+{% include reading-progress.html %}
 <article class="post-article" itemscope itemtype="https://schema.org/Article">
   <div class="post-meta-bar">
     {%- case page.category -%}

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -371,25 +371,48 @@ img { max-width: 100%; }
    POST / ARTICLE PAGE STYLES
    ============================================================ */
 
+/* Reading progress bar (shared across post + manuscript layouts) */
+.reading-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  z-index: 200;
+  pointer-events: none;
+  background: rgba(0, 0, 0, 0.07);
+}
+
+.reading-progress-bar {
+  height: 100%;
+  width: 0%;
+  background: var(--color-accent-gold);
+  transition: width 0.1s linear;
+  box-shadow: 0 0 6px rgba(197, 160, 47, 0.45);
+}
+
 .post-article {
   max-width: 720px;
   margin: 0 auto;
+  padding: 0 0.25rem;
 }
 
 .post-meta-bar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.5rem;
-  padding-bottom: 0.75rem;
+  margin: 0 0 3rem;
+  padding: 0.85rem 0;
+  border-top: 1px solid var(--color-charcoal);
   border-bottom: 1px solid var(--color-border-light);
 }
 
 .back-link {
-  font-size: 0.7rem;
-  font-weight: 600;
+  font-family: var(--font-sans);
+  font-size: 0.62rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.15em;
+  letter-spacing: 0.22em;
   color: var(--color-gray-500);
 }
 
@@ -402,36 +425,60 @@ img { max-width: 100%; }
 }
 
 .post-date {
-  font-size: 0.7rem;
-  font-weight: 600;
+  font-family: var(--font-sans);
+  font-size: 0.62rem;
+  font-weight: 700;
   color: var(--color-accent-red);
   text-transform: uppercase;
-  letter-spacing: 0.15em;
+  letter-spacing: 0.22em;
 }
 
 .post-title {
   font-family: var(--font-serif);
-  font-size: 2rem;
+  font-size: 2.45rem;
   font-weight: 700;
-  line-height: 1.35;
-  margin: 0 0 0.5rem;
+  line-height: 1.22;
+  margin: 0 0 1rem;
   color: var(--color-charcoal);
+  text-align: center;
+  letter-spacing: -0.005em;
 }
 
 .post-author {
-  font-size: 0.8rem;
+  display: block;
+  font-family: var(--font-serif);
+  font-size: 0.95rem;
+  font-style: italic;
   font-weight: 600;
-  color: var(--color-gray-500);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  margin-bottom: 1rem;
+  color: var(--color-charcoal);
+  text-align: center;
+  letter-spacing: 0.01em;
+  text-transform: none;
+  margin: 0 0 1.5rem;
+}
+
+.post-author::before {
+  content: "— ";
+  color: var(--color-accent-gold);
+  font-style: normal;
+  font-weight: 700;
+  margin-right: 0.15rem;
 }
 
 .post-divider {
-  width: 60px;
-  height: 3px;
-  background: var(--color-charcoal);
-  margin-bottom: 2rem;
+  width: auto;
+  height: auto;
+  background: none;
+  text-align: center;
+  margin: 0 auto 2.75rem;
+}
+
+.post-divider::before {
+  content: "◈  ◈  ◈";
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+  letter-spacing: 0.55em;
+  color: var(--color-accent-gold);
 }
 
 .post-breadcrumb,
@@ -466,21 +513,43 @@ img { max-width: 100%; }
 
 .post-content {
   font-family: var(--font-serif);
-  font-size: 1rem;
-  line-height: 2;
+  font-size: 1.05rem;
+  line-height: 1.95;
   color: var(--color-charcoal-light);
 }
 
 .post-content p {
-  margin: 0 0 1.25rem;
+  margin: 0 0 1.35rem;
 }
 
 .post-content h2,
 .post-content h3 {
   font-family: var(--font-serif);
   color: var(--color-charcoal);
-  margin-top: 2rem;
   border-bottom: none;
+  letter-spacing: -0.005em;
+}
+
+.post-content h2 {
+  font-size: 1.55rem;
+  font-weight: 700;
+  line-height: 1.35;
+  margin: 3rem 0 1.5rem;
+  padding-top: 1.75rem;
+  border-top: 1px solid var(--color-border-light);
+}
+
+.post-content h2:first-child,
+.post-content > h2:first-of-type {
+  margin-top: 2rem;
+}
+
+.post-content h3 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  line-height: 1.4;
+  margin: 2.25rem 0 1rem;
+  font-style: italic;
 }
 
 .post-content a {
@@ -494,10 +563,113 @@ img { max-width: 100%; }
 
 .post-content blockquote {
   border-left: 3px solid var(--color-accent-gold);
-  margin: 1.5rem 0;
-  padding: 0.5rem 1.5rem;
-  color: var(--color-gray-600);
+  margin: 2rem 0;
+  padding: 0.85rem 0 0.85rem 1.75rem;
+  color: var(--color-charcoal-light);
   font-style: italic;
+  background: transparent;
+}
+
+.post-content blockquote p {
+  margin: 0 0 0.85rem;
+}
+
+.post-content blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+/* Decorative section separator (hr between h2 sections) */
+.post-content hr {
+  border: none;
+  height: auto;
+  background: none;
+  text-align: center;
+  margin: 2.75rem 0;
+  overflow: visible;
+}
+
+.post-content hr::before {
+  content: "◈  ◈  ◈";
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  letter-spacing: 0.55em;
+  color: var(--color-accent-gold);
+}
+
+/* Kramdown table of contents — inline editorial style */
+.post-content #markdown-toc {
+  list-style: none;
+  margin: 2.25rem 0 3rem;
+  padding: 1.4rem 0 1.25rem;
+  border-top: 1px solid var(--color-border-light);
+  border-bottom: 1px solid var(--color-border-light);
+  counter-reset: qa-toc;
+}
+
+.post-content #markdown-toc::before {
+  content: "目录 / Contents";
+  display: block;
+  font-family: var(--font-sans);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--color-gray-500);
+  margin: 0 0 0.9rem;
+}
+
+.post-content #markdown-toc > li {
+  counter-increment: qa-toc;
+  position: relative;
+  padding: 0.32rem 0 0.32rem 2.5rem;
+  font-family: var(--font-serif);
+  font-size: 0.98rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.post-content #markdown-toc > li::before {
+  content: counter(qa-toc, decimal-leading-zero);
+  position: absolute;
+  left: 0;
+  top: 0.55rem;
+  font-family: var(--font-sans);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--color-accent-red);
+}
+
+.post-content #markdown-toc ul {
+  list-style: none;
+  padding-left: 1rem;
+  margin: 0.35rem 0 0;
+}
+
+.post-content #markdown-toc ul li {
+  padding: 0.2rem 0 0.2rem 1rem;
+  position: relative;
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.post-content #markdown-toc ul li::before {
+  content: "—";
+  position: absolute;
+  left: 0;
+  top: 0.2rem;
+  color: var(--color-accent-gold);
+  font-weight: 700;
+}
+
+.post-content #markdown-toc a {
+  color: var(--color-charcoal-light);
+  border-bottom: none;
+}
+
+.post-content #markdown-toc a:hover {
+  color: var(--color-accent-gold);
+  border-bottom: none;
 }
 
 /* ============================================================
@@ -1358,7 +1530,46 @@ summary h2 {
   }
 
   .post-title {
-    font-size: 1.5rem;
+    font-size: 1.7rem;
+    line-height: 1.28;
+  }
+
+  .post-meta-bar {
+    margin-bottom: 2rem;
+  }
+
+  .post-author {
+    font-size: 0.88rem;
+  }
+
+  .post-content {
+    font-size: 1rem;
+    line-height: 1.88;
+  }
+
+  .post-content h2 {
+    font-size: 1.3rem;
+    margin: 2.25rem 0 1.15rem;
+    padding-top: 1.35rem;
+  }
+
+  .post-content h3 {
+    font-size: 1.08rem;
+    margin: 1.75rem 0 0.85rem;
+  }
+
+  .post-content #markdown-toc {
+    margin: 1.75rem 0 2.25rem;
+    padding: 1.15rem 0 1rem;
+  }
+
+  .post-content #markdown-toc > li {
+    font-size: 0.92rem;
+    padding-left: 2.25rem;
+  }
+
+  .post-content #markdown-toc ul li {
+    font-size: 0.85rem;
   }
 
   .tab button {


### PR DESCRIPTION
将 Q&A 页的编辑排版语汇应用到 .post-article / .post-content：上下双 细线 meta 栏、2.45rem 居中大标题、斜体金色破折号署名、◈ ◈ ◈ 菱形
分隔符、1.05rem 衬线正文配 1.95 行高、h2 顶部细线节次分隔、Kramdown
目录改为带编号的内嵌式排版、段落 hr 升级为菱形分隔；增加全站通用
阅读进度条（post + manuscript 共用 _includes/reading-progress.html）， 覆盖约 637 篇文章。

同时关闭 Waline pageview 计数器，修复其后端 varchar(255) 因 URL 编码 中文过长导致的 500 错误。